### PR TITLE
Build Material Design 3 design system

### DIFF
--- a/app/src/main/java/dev/krgm4d/shiroguessr/ui/component/MaterialButtons.kt
+++ b/app/src/main/java/dev/krgm4d/shiroguessr/ui/component/MaterialButtons.kt
@@ -1,0 +1,185 @@
+package dev.krgm4d.shiroguessr.ui.component
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.unit.dp
+
+/**
+ * Material Design 3 Button Components for ShiroGuessr.
+ *
+ * Corresponds to the iOS version's MaterialButtonStyles.swift.
+ * All buttons include a press animation (scale down to 0.98) matching
+ * the iOS version's spring animation behavior.
+ */
+
+// Press animation constants matching iOS version (scaleEffect 0.98)
+private const val PRESSED_SCALE = 0.98f
+private const val DEFAULT_SCALE = 1.0f
+
+/**
+ * Creates a scale modifier that animates on press, matching the iOS version's
+ * spring(response: 0.3, dampingFraction: 0.7) animation.
+ */
+@Composable
+private fun Modifier.pressScale(interactionSource: MutableInteractionSource): Modifier {
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) PRESSED_SCALE else DEFAULT_SCALE,
+        animationSpec = spring(
+            dampingRatio = 0.7f,
+            stiffness = 500f
+        ),
+        label = "pressScale"
+    )
+    return this.scale(scale)
+}
+
+/**
+ * Filled button for primary actions.
+ *
+ * Uses the primary color as background with white text.
+ * Includes press animation (scale shrink).
+ */
+@Composable
+fun MdFilledButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    content: @Composable RowScope.() -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    Button(
+        onClick = onClick,
+        modifier = modifier.pressScale(interactionSource),
+        enabled = enabled,
+        shape = MaterialTheme.shapes.extraLarge,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        content = content
+    )
+}
+
+/**
+ * Filled tonal button for secondary actions.
+ *
+ * Uses the secondary container color as background.
+ * Includes press animation (scale shrink).
+ */
+@Composable
+fun MdFilledTonalButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    content: @Composable RowScope.() -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    FilledTonalButton(
+        onClick = onClick,
+        modifier = modifier.pressScale(interactionSource),
+        enabled = enabled,
+        shape = MaterialTheme.shapes.extraLarge,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        content = content
+    )
+}
+
+/**
+ * Outlined button with a border stroke.
+ *
+ * Uses the outline color for the border and primary color for text.
+ * Includes press animation (scale shrink).
+ */
+@Composable
+fun MdOutlinedButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    content: @Composable RowScope.() -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    OutlinedButton(
+        onClick = onClick,
+        modifier = modifier.pressScale(interactionSource),
+        enabled = enabled,
+        shape = MaterialTheme.shapes.extraLarge,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        content = content
+    )
+}
+
+/**
+ * Elevated button with a shadow.
+ *
+ * Uses the surface color as background with an elevation shadow.
+ * Includes press animation (scale shrink).
+ */
+@Composable
+fun MdElevatedButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    content: @Composable RowScope.() -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    ElevatedButton(
+        onClick = onClick,
+        modifier = modifier.pressScale(interactionSource),
+        enabled = enabled,
+        shape = MaterialTheme.shapes.extraLarge,
+        elevation = ButtonDefaults.elevatedButtonElevation(
+            defaultElevation = 2.dp,
+            pressedElevation = 0.dp
+        ),
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        content = content
+    )
+}
+
+/**
+ * Text button for the lowest-emphasis actions.
+ *
+ * No background or border; only text in the primary color.
+ * Includes press animation (scale shrink).
+ */
+@Composable
+fun MdTextButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    contentPadding: PaddingValues = ButtonDefaults.TextButtonContentPadding,
+    content: @Composable RowScope.() -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    TextButton(
+        onClick = onClick,
+        modifier = modifier.pressScale(interactionSource),
+        enabled = enabled,
+        shape = MaterialTheme.shapes.extraLarge,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        content = content
+    )
+}

--- a/app/src/main/java/dev/krgm4d/shiroguessr/ui/theme/Color.kt
+++ b/app/src/main/java/dev/krgm4d/shiroguessr/ui/theme/Color.kt
@@ -2,10 +2,47 @@ package dev.krgm4d.shiroguessr.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
+/**
+ * Material Design 3 Color System for ShiroGuessr.
+ *
+ * Based on the iOS version's ColorSystem.swift, adapted for Jetpack Compose.
+ * This game deals with white colors, so only a light theme is supported.
+ */
 
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+// Primary Colors
+val MdPrimary = Color(0xFF617CFB) // Material Blue (rgb 0.38, 0.49, 0.98)
+val MdOnPrimary = Color.White
+val MdPrimaryContainer = Color(0xFFDEE6FF) // rgb 0.87, 0.90, 1.0
+val MdOnPrimaryContainer = Color(0xFF00216B) // rgb 0.0, 0.13, 0.42
+
+// Secondary Colors
+val MdSecondary = Color(0xFF5C6E9E) // rgb 0.36, 0.43, 0.62
+val MdOnSecondary = Color.White
+val MdSecondaryContainer = Color(0xFFD9E3FF) // rgb 0.85, 0.89, 1.0
+val MdOnSecondaryContainer = Color(0xFF0F214A) // rgb 0.06, 0.13, 0.29
+
+// Tertiary Colors
+val MdTertiary = Color(0xFFA14F94) // rgb 0.63, 0.31, 0.58
+val MdOnTertiary = Color.White
+val MdTertiaryContainer = Color(0xFFF5D9F0) // rgb 0.96, 0.85, 0.94
+val MdOnTertiaryContainer = Color(0xFF470F40) // rgb 0.28, 0.06, 0.25
+
+// Error Colors
+val MdError = Color(0xFFBA1C1C) // rgb 0.73, 0.11, 0.11
+val MdOnError = Color.White
+val MdErrorContainer = Color(0xFFFFD9D9) // rgb 1.0, 0.85, 0.85
+val MdOnErrorContainer = Color(0xFF680000) // rgb 0.41, 0.0, 0.0
+
+// Background Colors
+val MdBackground = Color(0xFFFCFCFF) // rgb 0.99, 0.99, 1.0
+val MdOnBackground = Color(0xFF1C1C21) // rgb 0.11, 0.11, 0.13
+
+// Surface Colors
+val MdSurface = Color(0xFFFCFCFF) // rgb 0.99, 0.99, 1.0
+val MdOnSurface = Color(0xFF1C1C21) // rgb 0.11, 0.11, 0.13
+val MdSurfaceVariant = Color(0xFFE0E6F5) // rgb 0.88, 0.90, 0.96
+val MdOnSurfaceVariant = Color(0xFF454A54) // rgb 0.27, 0.29, 0.33
+
+// Outline Colors
+val MdOutline = Color(0xFF757885) // rgb 0.46, 0.47, 0.52
+val MdOutlineVariant = Color(0xFFC7C9D9) // rgb 0.78, 0.79, 0.85

--- a/app/src/main/java/dev/krgm4d/shiroguessr/ui/theme/Theme.kt
+++ b/app/src/main/java/dev/krgm4d/shiroguessr/ui/theme/Theme.kt
@@ -1,57 +1,57 @@
 package dev.krgm4d.shiroguessr.ui.theme
 
-import android.app.Activity
-import android.os.Build
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
 
-private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80
+/**
+ * ShiroGuessr custom light color scheme.
+ *
+ * Dynamic color is intentionally disabled because this game requires
+ * fixed colors for the white-color guessing mechanic.
+ * Only a light theme is used, matching the iOS version's
+ * `.preferredColorScheme(.light)` enforcement.
+ */
+private val ShiroGuessrColorScheme = lightColorScheme(
+    primary = MdPrimary,
+    onPrimary = MdOnPrimary,
+    primaryContainer = MdPrimaryContainer,
+    onPrimaryContainer = MdOnPrimaryContainer,
+    secondary = MdSecondary,
+    onSecondary = MdOnSecondary,
+    secondaryContainer = MdSecondaryContainer,
+    onSecondaryContainer = MdOnSecondaryContainer,
+    tertiary = MdTertiary,
+    onTertiary = MdOnTertiary,
+    tertiaryContainer = MdTertiaryContainer,
+    onTertiaryContainer = MdOnTertiaryContainer,
+    error = MdError,
+    onError = MdOnError,
+    errorContainer = MdErrorContainer,
+    onErrorContainer = MdOnErrorContainer,
+    background = MdBackground,
+    onBackground = MdOnBackground,
+    surface = MdSurface,
+    onSurface = MdOnSurface,
+    surfaceVariant = MdSurfaceVariant,
+    onSurfaceVariant = MdOnSurfaceVariant,
+    outline = MdOutline,
+    outlineVariant = MdOutlineVariant
 )
 
-private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
-)
-
+/**
+ * Application theme for ShiroGuessr.
+ *
+ * Always uses the light theme with a fixed color scheme.
+ * Dynamic color is disabled to ensure consistent color presentation
+ * across all devices, which is essential for a color-guessing game.
+ */
 @Composable
 fun ShiroGuessrAndroidTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
-
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
-    }
-
     MaterialTheme(
-        colorScheme = colorScheme,
+        colorScheme = ShiroGuessrColorScheme,
         typography = Typography,
         content = content
     )

--- a/app/src/main/java/dev/krgm4d/shiroguessr/ui/theme/Type.kt
+++ b/app/src/main/java/dev/krgm4d/shiroguessr/ui/theme/Type.kt
@@ -6,22 +6,119 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-// Set of Material typography styles to start with
+/**
+ * Material Design 3 Typography Scale for ShiroGuessr.
+ *
+ * Defines the full MD3 type scale matching the iOS version's typography definitions.
+ * See: https://m3.material.io/styles/typography/type-scale-tokens
+ */
 val Typography = Typography(
+    // Display
+    displayLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 57.sp,
+        lineHeight = 64.sp,
+        letterSpacing = (-0.25).sp
+    ),
+    displayMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 45.sp,
+        lineHeight = 52.sp,
+        letterSpacing = 0.sp
+    ),
+    displaySmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 36.sp,
+        lineHeight = 44.sp,
+        letterSpacing = 0.sp
+    ),
+
+    // Headline
+    headlineLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 32.sp,
+        lineHeight = 40.sp,
+        letterSpacing = 0.sp
+    ),
+    headlineMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 28.sp,
+        lineHeight = 36.sp,
+        letterSpacing = 0.sp
+    ),
+    headlineSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 24.sp,
+        lineHeight = 32.sp,
+        letterSpacing = 0.sp
+    ),
+
+    // Title
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+        letterSpacing = 0.sp
+    ),
+    titleMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.15.sp
+    ),
+    titleSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp
+    ),
+
+    // Body
     bodyLarge = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp,
         lineHeight = 24.sp,
         letterSpacing = 0.5.sp
-    )
-    /* Other default text styles to override
-    titleLarge = TextStyle(
+    ),
+    bodyMedium = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,
-        fontSize = 22.sp,
-        lineHeight = 28.sp,
-        letterSpacing = 0.sp
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.25.sp
+    ),
+    bodySmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.4.sp
+    ),
+
+    // Label
+    labelLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.1.sp
+    ),
+    labelMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
     ),
     labelSmall = TextStyle(
         fontFamily = FontFamily.Default,
@@ -30,5 +127,4 @@ val Typography = Typography(
         lineHeight = 16.sp,
         letterSpacing = 0.5.sp
     )
-    */
 )


### PR DESCRIPTION
## Summary

- Define a full MD3 color palette in `Color.kt` based on the iOS version's `ColorSystem.swift`, covering primary, secondary, tertiary, error, background, surface, and outline color roles
- Implement the complete MD3 typography scale (Display/Headline/Title/Body/Label at Large/Medium/Small) in `Type.kt`
- Create five button composables in `ui/component/MaterialButtons.kt` (MdFilledButton, MdFilledTonalButton, MdOutlinedButton, MdElevatedButton, MdTextButton) with press-scale animation matching the iOS version's spring behavior
- Simplify `Theme.kt` to use a fixed light-only color scheme with dynamic color disabled, ensuring consistent colors for the white-color guessing game

Closes #2

## Test plan

- [x] `./gradlew compileDebugKotlin` passes
- [x] `./gradlew test` passes (all unit tests)
- [x] `./gradlew lint` passes with no errors
- [ ] Verify the app launches with the new theme applied on a device/emulator
- [ ] Confirm button press animations render correctly

Generated with [Claude Code](https://claude.com/claude-code)