### PR TITLE
Fix #24: AppBarのサイズを小さくする

### DIFF
--- a/app/src/main/java/dev/krgm4d/shiroguessr/ui/component/GameHeader.kt
+++ b/app/src/main/java/dev/krgm4d/shiroguessr/ui/component/GameHeader.kt
@@ -44,11 +44,11 @@ fun GameHeader(
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                .padding(horizontal = 16.dp, vertical = 4.dp),
         ) {
             Text(
                 text = stringResource(R.string.app_title),
-                style = MaterialTheme.typography.headlineLarge,
+                style = MaterialTheme.typography.titleLarge,
                 color = MaterialTheme.colorScheme.onSurface,
             )
 


### PR DESCRIPTION
## Summary

- Reduced the GameHeader (AppBar) size to be more compact, giving more screen space to game content
- Changed title typography from `headlineLarge` to `titleLarge` (Material Design 3)
- Reduced vertical padding from `12.dp` to `4.dp`

Closes #24

## Test plan

- [x] Lint check passes (`./gradlew lintDebug`)
- [x] Unit tests pass (`./gradlew testDebugUnitTest`)
- [ ] Visually verify the AppBar is noticeably smaller on device/emulator
- [ ] Verify the mode toggle button remains accessible and properly aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)