### PR TITLE
Fix #25: Lock app to portrait orientation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
+            android:screenOrientation="portrait"
             android:theme="@style/Theme.ShiroGuessrAndroid.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
## Summary
- Add `android:screenOrientation="portrait"` to `MainActivity` in `AndroidManifest.xml` to lock the app to portrait mode and disable landscape rotation

Closes #25

## Test plan
- [ ] Verify the app launches in portrait mode
- [ ] Rotate the device and confirm the app stays in portrait orientation
- [ ] Confirm no regression in existing UI layout

Generated with [Claude Code](https://claude.com/claude-code)