### PR TITLE
Change app icon background to dark color

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -5,6 +5,6 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
     <path
-        android:fillColor="#FFFFFF"
+        android:fillColor="#1A1C1E"
         android:pathData="M0,0h108v108h-108z" />
 </vector>


### PR DESCRIPTION
## Summary

- Change the adaptive icon background color from white (`#FFFFFF`) to dark (`#1A1C1E`) to improve contrast
- Addresses the request in issue #26 to make the app icon background black-based

Closes #26

## Test plan

- [ ] Verify the app icon renders correctly on the home screen with the new dark background
- [ ] Check adaptive icon appearance on different launcher shapes (circle, squircle, square)
- [ ] Confirm the foreground icon remains clearly visible against the dark background

Generated with [Claude Code](https://claude.com/claude-code)