### PR TITLE
Add App Links support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,17 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="shiro-guessr.pages.dev"
+                    android:pathPrefix="/app" />
+            </intent-filter>
         </activity>
     </application>
 


### PR DESCRIPTION
## Summary
- `https://shiro-guessr.pages.dev/app` へのApp Linksに対応
- AndroidManifest.xmlにautoVerify付きのintent-filterを追加

## Note
サーバー側に `https://shiro-guessr.pages.dev/.well-known/assetlinks.json` の配置が必要です。

## Test plan
- [ ] `adb shell am start -a android.intent.action.VIEW -d "https://shiro-guessr.pages.dev/app"` でアプリが起動することを確認
- [ ] assetlinks.jsonの配置後、App Linksの自動検証が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)