### PR TITLE
Improve CD: debug symbols upload and auto-increment build number

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
 
 concurrency:
   group: cd-release
@@ -48,6 +47,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          VERSION_CODE: ${{ vars.BUILD_NUMBER }}
         run: ./gradlew bundleRelease assembleRelease
 
       - name: Upload to Google Play Store
@@ -60,19 +60,50 @@ jobs:
           releaseFiles: app/build/outputs/bundle/release/app-release.aab
           track: internal
           status: completed
+          debugSymbols: app/build/intermediates/merged_native_libs/release/mergeReleaseNativeLibs/out/lib
+          mappingFile: app/build/outputs/mapping/release/mapping.txt
 
       - name: Warn if Play Store upload failed
         if: steps.play-upload.outcome == 'failure'
         run: echo "::warning::Google Play Store upload failed. Please upload manually."
+
+      - name: Package debug symbols for manual upload
+        if: steps.play-upload.outcome == 'failure'
+        run: |
+          SYMBOLS_DIR=app/build/intermediates/merged_native_libs/release/mergeReleaseNativeLibs/out/lib
+          MAPPING_FILE=app/build/outputs/mapping/release/mapping.txt
+          mkdir -p debug-symbols
+          if [ -d "$SYMBOLS_DIR" ]; then
+            cp -r "$SYMBOLS_DIR" debug-symbols/native-debug-symbols
+          fi
+          if [ -f "$MAPPING_FILE" ]; then
+            cp "$MAPPING_FILE" debug-symbols/mapping.txt
+          fi
+          if [ "$(ls -A debug-symbols)" ]; then
+            cd debug-symbols && zip -r ../debug-symbols.zip . && cd ..
+          fi
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          fail_on_unmatched_files: false
           files: |
             app/build/outputs/bundle/release/app-release.aab
             app/build/outputs/apk/release/app-release.apk
+            debug-symbols.zip
+
+      - name: Increment BUILD_NUMBER
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEXT_BUILD_NUMBER=$(( ${{ vars.BUILD_NUMBER }} + 1 ))
+          gh api --method PATCH \
+            repos/${{ github.repository }}/actions/variables/BUILD_NUMBER \
+            -f name='BUILD_NUMBER' \
+            -f value="${NEXT_BUILD_NUMBER}"
+          echo "BUILD_NUMBER incremented to ${NEXT_BUILD_NUMBER}"
 
       - name: Clean up keystore
         if: always()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,7 +33,7 @@ android {
         applicationId = "dev.krgm4d.shiroguessr"
         minSdk = 29
         targetSdk = 36
-        versionCode = 1
+        versionCode = (System.getenv("VERSION_CODE")?.toIntOrNull() ?: 1)
         versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## Summary
- Play Storeへのアップロード時にネイティブデバッグシンボルと難読化解除ファイル(mapping.txt)を含めるように変更
- Play Storeアップロード失敗時、debug-symbols.zipをGitHub Releaseのアーティファクトに添付
- `versionCode`をRepository Variable `BUILD_NUMBER` で管理し、CDパイプライン内で自動インクリメント

## Test plan
- [ ] Repository Variableに `BUILD_NUMBER` を作成して値を設定
- [ ] タグをpushしてCDが正常に動作することを確認
- [ ] ビルド後に `BUILD_NUMBER` がインクリメントされていることを確認
- [ ] Play Storeアップロード失敗時にdebug-symbols.zipがReleaseに含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)