### PR TITLE
Fix CD: add actions:write permission and clean up debug symbols

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
 
     steps:
       - name: Checkout repository
@@ -75,12 +76,13 @@ jobs:
           mkdir -p debug-symbols
           if [ -d "$SYMBOLS_DIR" ]; then
             cp -r "$SYMBOLS_DIR" debug-symbols/native-debug-symbols
+            rm -rf debug-symbols/native-debug-symbols/x86 debug-symbols/native-debug-symbols/x86_64
           fi
           if [ -f "$MAPPING_FILE" ]; then
             cp "$MAPPING_FILE" debug-symbols/mapping.txt
           fi
           if [ "$(ls -A debug-symbols)" ]; then
-            cd debug-symbols && zip -r ../debug-symbols.zip . && cd ..
+            cd debug-symbols && zip -r ../debug-symbols.zip . -x "*.DS_Store" "*__MACOSX*" && cd ..
           fi
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary
- BUILD_NUMBER変数の更新に必要な `actions: write` 権限を追加
- デバッグシンボルアーカイブからx86/x86_64を除外
- zipから `.DS_Store` と `__MACOSX` を除外

## Test plan
- [ ] CDパイプラインでIncrement BUILD_NUMBERステップが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)