### PR TITLE
Enable R8 minification for release builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,7 +55,8 @@ android {
             )
         }
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -5,17 +5,18 @@
 # For more details, see
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# Preserve line number information for debugging stack traces
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# kotlinx-serialization
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.AnnotationsKt
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+-keepclassmembers @kotlinx.serialization.Serializable class ** {
+    *** Companion;
+}
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1>$Companion {
+    kotlinx.serialization.KSerializer serializer(...);
+}


### PR DESCRIPTION
## Summary
- リリースビルドで `isMinifyEnabled` と `isShrinkResources` を有効化
- APKサイズ削減 + Play Store アップロード時に必要な `mapping.txt` が生成されるようになる
- kotlinx-serialization 用の ProGuard ルールを追加

## Context
CD の Play Store アップロードが `mapping.txt` が存在しないため失敗していた:
```
ENOENT: no such file or directory, open 'app/build/outputs/mapping/release/mapping.txt'
```

## Test plan
- [x] `assembleDebug` ビルド成功
- [x] `testDebugUnitTest` テスト成功
- [ ] CI で `assembleRelease` が成功し mapping.txt が生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)