### PR TITLE
Fix R8 crash at startup

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,3 +20,20 @@
 -keepclassmembers class <1>$Companion {
     kotlinx.serialization.KSerializer serializer(...);
 }
+
+# Room - keep generated database and DAO implementations
+-keep class * extends androidx.room.RoomDatabase
+-keep class * extends androidx.room.RoomDatabase { *; }
+-keep class **_Impl { *; }
+-keep @androidx.room.Dao class *
+-keepclassmembers @androidx.room.Dao class * { *; }
+-keep @androidx.room.Entity class * { *; }
+
+# WorkManager
+-keep class * extends androidx.work.WorkerParameters
+-keep class * extends androidx.work.ListenableWorker {
+    public <init>(android.content.Context, androidx.work.WorkerParameters);
+}
+
+# AndroidX Startup
+-keep class * extends androidx.startup.Initializer { *; }


### PR DESCRIPTION
## Summary
- R8 minification was stripping Room's generated `_Impl` classes, causing `WorkDatabase` instantiation to fail and crash on startup
- Added ProGuard keep rules for Room (databases, DAOs, entities, `_Impl` classes), WorkManager workers, and AndroidX Startup initializers

## Test plan
- [x] Install minified debug build on device and confirm app launches without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)